### PR TITLE
gingonic package from gopkg.in

### DIFF
--- a/gingonic/gingonic.go
+++ b/gingonic/gingonic.go
@@ -2,9 +2,9 @@ package gingonic
 
 import (
 	"net/http"
-
-	"gopkg.in/gin-gonic/gin.v1"
+	
 	"github.com/manyminds/api2go/routing"
+	"gopkg.in/gin-gonic/gin.v1"
 )
 
 type ginRouter struct {

--- a/gingonic/gingonic.go
+++ b/gingonic/gingonic.go
@@ -3,7 +3,7 @@ package gingonic
 import (
 	"net/http"
 
-	"github.com/gin-gonic/gin"
+	"gopkg.in/gin-gonic/gin.v1"
 	"github.com/manyminds/api2go/routing"
 )
 

--- a/gingonic/gingonic_test.go
+++ b/gingonic/gingonic_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 
-	"github.com/gin-gonic/gin"
+	"gopkg.in/gin-gonic/gin.v1"
 	"github.com/manyminds/api2go"
 	. "github.com/manyminds/api2go-adapter/gingonic"
 	"github.com/manyminds/api2go/examples/model"

--- a/gingonic/gingonic_test.go
+++ b/gingonic/gingonic_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 
-	"gopkg.in/gin-gonic/gin.v1"
+	
 	"github.com/manyminds/api2go"
 	. "github.com/manyminds/api2go-adapter/gingonic"
 	"github.com/manyminds/api2go/examples/model"
@@ -17,6 +17,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"gopkg.in/gin-gonic/gin.v1"
 )
 
 var _ = Describe("api2go with gingonic router adapter", func() {


### PR DESCRIPTION
gingonic officially uses gopkg.in, all middleware and contrib packages such as cors etc. import it via gopkg.in. this leaves it impossible to use api2go together with gin using their official packages such as gin-contrib/cors etc. same problem would arise with any package that use gopkg.in and most of them do as that's what is the official way to import from gins github page. please consider changing the package import in this merge request from github to gopkg for compatibility with github.com/gin-gonic/gin