### PR TITLE
Deprecate adapter repository in favor of mainline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# api2go-adapter 
+# api2go-adapter
 
 [![Join the chat at https://gitter.im/manyminds/api2go-adapter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/manyminds/api2go-adapter?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -6,15 +6,11 @@
 [![Coverage Status](https://coveralls.io/repos/manyminds/api2go-adapter/badge.svg?branch=master&service=github)](https://coveralls.io/github/manyminds/api2go-adapter?branch=master)
 [![Go Report Card](http://goreportcard.com/badge/manyminds/api2go-adapter)](http://goreportcard.com/report/manyminds/api2go-adapter)
 
-This package provides useful adapters to use api2go with differnet frameworks.
+### Deprecated
 
-## Gin
+All adapters got moved into the main repository and will only be updated there.
 
-[Gin Framework Adapter](https://github.com/manyminds/api2go-adapter/tree/master/gingonic)
+#### Upgrade
+To Upgrade the gin-adapter from api2go-adapter simply install api2go with the build tag:
 
-[![GoDoc](https://godoc.org/github.com/manyminds/api2go-adapter/gingonic?status.svg)](https://godoc.org/github.com/manyminds/api2go-adapter/gingonic)
-
-
-[Gorilla Mux Adapter](https://github.com/manyminds/api2go-adapter/tree/master/gorillamux)
-
-[![GoDoc](https://godoc.org/github.com/manyminds/api2go-adapter/gorillamux?status.svg)](https://godoc.org/github.com/manyminds/api2go-adapter/gorillamux)
+`go get -tags=gingonic github.com/manyminds/api2go` and replace `gingonic.New(r)` with `routing.Gin(r)`


### PR DESCRIPTION
Can be merged after https://github.com/manyminds/api2go/pull/299 has been merged