### PR TITLE
Update handler call

### DIFF
--- a/gingonic/gingonic.go
+++ b/gingonic/gingonic.go
@@ -23,7 +23,7 @@ func (g ginRouter) Handle(protocol, route string, handler routing.HandlerFunc) {
 			params[p.Key] = p.Value
 		}
 
-		handler(c.Writer, c.Request, params)
+		handler(c.Writer, c.Request, params, c.Keys)
 	}
 
 	g.router.Handle(protocol, route, wrappedCallback)


### PR DESCRIPTION
The newest version of api2go router doesn't work with this handler signature.